### PR TITLE
If there is no version - use 0.0.0 as starting one

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const getAction = (question, values) => {
 }
 
 const getCurrentVersion = (fileData) => {
-    return fileData.version.split('.').map(item => Number(item));
+    return (fileData.version || "0.0.0").split('.').map(item => Number(item));
 }
 
 const getNewVersion = (version, action) => {


### PR DESCRIPTION
Fix for this error:
Semantic version:

D:\AProgs\nvm\v15.4.0\node_modules\version-select\index.js:21
    return fileData.version.split('.').map(item => Number(item));
                            ^

TypeError: Cannot read property 'split' of undefined
    at getCurrentVersion (D:\AProgs\nvm\v15.4.0\node_modules\version-select\index.js:21:29)
    at updateVersion (D:\AProgs\nvm\v15.4.0\node_modules\version-select\index.js:54:28)
    at processTicksAndRejections (node:internal/process/task_queues:93:5)
npm ERR! code 1
npm ERR! path D:\b\Mine\GIT_Work\ytransport_server
npm ERR! command failed
npm ERR! command C:\WINDOWS\system32\cmd.exe /d /s /c version-select

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\Nname\AppData\Local\npm-cache\_logs\2021-08-26T05_18_49_877Z-debug.log
npm ERR! code 1
npm ERR! path D:\b\Mine\GIT_Work\ytransport_server
npm ERR! command failed
npm ERR! command C:\WINDOWS\system32\cmd.exe /d /s /c npm run build_lite && npx version-select && yb genprojmeta && npm publish

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\Nname\AppData\Local\npm-cache\_logs\2021-08-26T05_18_49_902Z-debug.log