### PR TITLE
Added 'keep' option and version preview

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const FILE = 'package.json';
 const PATCH = "Patch";
 const MINOR = "Minor";
 const MAJOR = "Major";
+const KEEP = "Keep";
 
 const getAction = (question, values) => {
     console.log(question);
@@ -35,6 +36,8 @@ const getNewVersion = (version, action) => {
             version[1] = 0;
             version[2] = 0;
             break;
+        case KEEP:
+            break;
     }
 
     return version.join('.');
@@ -45,14 +48,23 @@ const setNewVersion = async (fileData, version) => {
 }
 
 const updateVersion = async () => {
-    const action = await getAction('Semantic version:'.green, [PATCH, MINOR, MAJOR]);
     const fileData = JSON.parse(fs.readFileSync(FILE));
+    const currentVersion = getCurrentVersion(fileData);
+    const current = fileData.version;
+    const action = await getAction('Semantic version:'.green, [
+        `${PATCH} ${current} -> ${getNewVersion([...currentVersion], PATCH)}`,
+        `${MINOR} ${current} -> ${getNewVersion([...currentVersion], MINOR)}`,
+        `${MAJOR} ${current} -> ${getNewVersion([...currentVersion], MAJOR)}`,
+        `${KEEP} ${current}`
+    ]);
+    const currentAction = action.split(' ')[0];
+
+    if(currentAction == KEEP) return;
 
     const { size } = fs.statSync(FILE);
     if (!size) { return new Error('Incorrect path') }
 
-    const currentVersion = getCurrentVersion(fileData);
-    const newVersion = getNewVersion(currentVersion, action);
+    const newVersion = getNewVersion(currentVersion, currentAction);
     console.log(newVersion.yellow);
     return setNewVersion(fileData, newVersion);
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -23,5 +23,9 @@ describe('Main', () => {
             const result = getNewVersion([3, 4, 5], 'Major');
             assert.equal(result, "4.0.0");
         });
+        it('should keep current version for Keep action', () => {
+            const result = getNewVersion([3, 4, 5], 'Keep');
+            assert.equal(result, "3.4.5");
+        });
     });
 });


### PR DESCRIPTION
Added 'keep' option and version preview to menu items. Keep option is needed in case when automated CI/CD fail and won't publish new package - then on next run one likely want to preserve current already incremented version.